### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/getTempDir.js
+++ b/lib/getTempDir.js
@@ -3,7 +3,7 @@
 var fs = require( 'fs-extra' );
 var os = require( 'os' );
 var path = require( 'path' );
-var uuid = require( 'node-uuid' );
+var uuid = require( 'uuid' );
 
 
 function getTempDir() {

--- a/lib/git.js
+++ b/lib/git.js
@@ -2,7 +2,7 @@
 
 var path = require( 'path' );
 var fs = require( 'fs-extra' );
-var uuid = require( 'node-uuid' );
+var uuid = require( 'uuid' );
 var getTempDir = require( './getTempDir.js' );
 var doSpawn = require( './doSpawn.js' );
 

--- a/lib/svn.js
+++ b/lib/svn.js
@@ -2,7 +2,7 @@
 
 var path = require( 'path' );
 var fs = require( 'fs-extra' );
-var uuid = require( 'node-uuid' );
+var uuid = require( 'uuid' );
 var svn = require( 'node-svn-ultimate' );
 var spawn = require( 'child_process' ).spawn;
 var getTempDir = require( './getTempDir.js' );

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "babel-runtime": "^6.3.19",
     "fs-extra": "^0.26.2",
     "node-svn-ultimate": "^1.0.2",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -5,7 +5,7 @@ var os = require( 'os' );
 var path = require('path');
 var assert = require( 'assert' );
 var fs = require( 'fs-extra' );
-var uuid = require( 'node-uuid' );
+var uuid = require( 'uuid' );
 var helpers = require( '../testutil/helpers.js' );
 var gs = require('..' );
 

--- a/testutil/helpers.js
+++ b/testutil/helpers.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs-extra');
 var path = require('path');
-var uuid = require( 'node-uuid' );
+var uuid = require( 'uuid' );
 var getTempDir = require( '../lib/getTempDir.js' );
 
 // replacement for mocha's it() method to return a promise instead of accept a callback


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.